### PR TITLE
Fix includes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,26 +14,25 @@ def get_version(source='vcfnp.pyx'):
     raise ValueError("__version__ not found")
 
 
-
 vcflib_dir = os.path.join(os.getcwd(), 'vcflib')
 smithwaterman_dir = os.path.join(vcflib_dir, 'smithwaterman')
 tabixpp_dir = os.path.join(vcflib_dir, 'tabixpp')
 
-
 vcflib_sources = ('Variant.cpp', 'ssw.c', 'ssw_cpp.cpp', 'split.cpp')
-smithwaterman_sources = ('BandedSmithWaterman.cpp', 
-                         'SmithWatermanGotoh.cpp', 
-                         'Repeats.cpp', 
-                         'disorder.c', 
-                         'LeftAlign.cpp', 
+smithwaterman_sources = ('BandedSmithWaterman.cpp',
+                         'SmithWatermanGotoh.cpp',
+                         'Repeats.cpp',
+                         'disorder.c',
+                         'LeftAlign.cpp',
                          'IndelAllele.cpp')
-tabixpp_sources = ('bedidx.c', 'bgzf.c', 'index.c', 'knetfile.c', 'kstring.c', 'tabix.cpp')
+tabixpp_sources = ('bedidx.c', 'bgzf.c', 'index.c', 'knetfile.c', 'kstring.c',
+                   'tabix.cpp')
 
 
 def get_vcflib_sources():
     sources = list()
     sources += [os.path.join(vcflib_dir, s) for s in vcflib_sources]
-    sources += [os.path.join(smithwaterman_dir, s) for s in smithwaterman_sources]    
+    sources += [os.path.join(smithwaterman_dir, s) for s in smithwaterman_sources]
     sources += [os.path.join(tabixpp_dir, s) for s in tabixpp_sources]
     return sources
 
@@ -41,27 +40,27 @@ def get_vcflib_sources():
 vcflib_extension = Extension('vcflib',
                              sources=['vcflib.pyx'] + get_vcflib_sources(),
                              language='c++',
-                             include_dirs=[np.get_include(),vcflib_dir,
+                             include_dirs=[np.get_include(), vcflib_dir,
                                            smithwaterman_dir, tabixpp_dir,
                                            '.'],
                              libraries=['m', 'z'],
                              extra_compile_args=['-O3'],
                              )
-    
+
 
 vcfnp_extension = Extension('vcfnp',
                             sources=['vcfnp.pyx'] + get_vcflib_sources(),
                             language='c++',
-                            include_dirs=[np.get_include(), vcflib_dir, 
-                                          smithwaterman_dir, 
+                            include_dirs=[np.get_include(), vcflib_dir,
+                                          smithwaterman_dir,
                                           tabixpp_dir, '.'],
                             libraries=['m', 'z'],
                             extra_compile_args=['-O3'],
                             )
-    
+
 
 setup(
-    name = 'vcfnp',
+    name='vcfnp',
     version=get_version(),
     author='Alistair Miles',
     author_email='alimanfoo@googlemail.com',
@@ -74,8 +73,6 @@ setup(
                  'Programming Language :: Python',
                  'Topic :: Software Development :: Libraries :: Python Modules'
                  ],
-    cmdclass = {'build_ext': build_ext},
-    ext_modules = [vcflib_extension, vcfnp_extension],
+    cmdclass={'build_ext': build_ext},
+    ext_modules=[vcflib_extension, vcfnp_extension],
     )
-
-


### PR DESCRIPTION
Fix building with system-wide installed numpy.

The script assumes the numpy includes are in the same directory, which is not true for Linux distribution-added packages. numpy.get_include()  gives the right path and as such is used.
