### PR TITLE
Added explicit numpy header include to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from distutils.extension import Extension
 from Cython.Build import cythonize
 import os
 from ast import literal_eval
+import numpy as np
 
 
 def get_version(source='vcfnp/__init__.py'):
@@ -88,4 +89,5 @@ setup(
              'scripts/qsub_vcf2npy',
              'scripts/vcfnpy2hdf5',
              'scripts/vcf2csv'],
+    include_dirs=[np.get_include()]             
 )

--- a/vcfnp/array.py
+++ b/vcfnp/array.py
@@ -51,7 +51,7 @@ def variants(vcf_fn, region=None, fields=None, exclude_fields=None, dtypes=None,
     dtypes: dict or dict-like, optional
         Dictionary cotaining dtypes to use instead of the default inferred ones.
     arities: dict or dict-like, optional
-        Dictinoary containing field:integer mappings used to override the number
+        Dictionary containing field:integer mappings used to override the number
         of values to expect.
     fills: dict or dict-like, optional
         Dictionary containing field:fillvalue mappings used to override the


### PR DESCRIPTION
This fixes a build-time error that I saw:

```
    vcfnp/iter.cpp:354:10: fatal error: 'numpy/arrayobject.h' file not found
    #include "numpy/arrayobject.h"
```