### PR TITLE
bugfix for vcf2hdf5_parallel

### DIFF
--- a/scripts/vcf2hdf5_parallel
+++ b/scripts/vcf2hdf5_parallel
@@ -253,6 +253,17 @@ def Main(argv=None):
                     chrom = fields[args.regions_column].split(':')[0]
                     if chrom not in chrom_list:
                         chrom_list[chrom] = True
+
+    # check chrom_list for invalid chars '_' and ':'
+    # @TCC at least '_' could probably be allowed if vcf2npy output file nameing was changed (need a separator between chrom and position range)
+    for c in chrom_list:
+        if '_' in c:
+            logging.critical("character '_' in chrom name '{}' will probably break this script".format(c))
+            sys.exit(2)
+        if ':' in c:
+            logging.critical("character ':' in chrom name '{}' will probably break this script".format(c))
+            sys.exit(2)
+             
     logging.debug("region_list={}".format(region_list))
     logging.debug("chrom_list={}".format(chrom_list))
     logging.info("decomposing into {} tasks".format(len(region_list)))
@@ -348,7 +359,7 @@ def Main(argv=None):
                 '--vcf', args.vcf,
                 '--input-dir', outdir,
                 '--input-filename-template',
-                '{{array_type}}.{}*.npy'.format(chrom),
+                '{{array_type}}.{}_*.npy'.format(chrom),
                 '--group', chrom,
                 '--output', hdf5_out_filename,
                 '--compression', args.hdf5_compression,

--- a/scripts/vcf2hdf5_parallel
+++ b/scripts/vcf2hdf5_parallel
@@ -257,8 +257,8 @@ def Main(argv=None):
     # check chrom_list for invalid chars '_' and ':'
     # @TCC at least '_' could probably be allowed if vcf2npy output file nameing was changed (need a separator between chrom and position range)
     for c in chrom_list:
-        if '_' in c:
-            logging.critical("character '_' in chrom name '{}' will probably break this script".format(c))
+        if '__' in c:
+            logging.critical("substring '__' in chrom name '{}' may break this script".format(c))
             sys.exit(2)
         if ':' in c:
             logging.critical("character ':' in chrom name '{}' will probably break this script".format(c))
@@ -359,7 +359,7 @@ def Main(argv=None):
                 '--vcf', args.vcf,
                 '--input-dir', outdir,
                 '--input-filename-template',
-                '{{array_type}}.{}_*.npy'.format(chrom),
+                '{{array_type}}.{}__*.npy'.format(chrom),
                 '--group', chrom,
                 '--output', hdf5_out_filename,
                 '--compression', args.hdf5_compression,

--- a/scripts/vcf2hdf5_parallel
+++ b/scripts/vcf2hdf5_parallel
@@ -352,9 +352,9 @@ def Main(argv=None):
                 '--group', chrom,
                 '--output', hdf5_out_filename,
                 '--compression', args.hdf5_compression,
-                '--compression-opts', args.hdf5_compression_opts,
-                '--chunk-size', args.hdf5_chunk_size,
-                '--chunk-width', args.hdf5_chunk_width,
+                '--compression-opts', str(args.hdf5_compression_opts),
+                '--chunk-size', str(args.hdf5_chunk_size),
+                '--chunk-width', str(args.hdf5_chunk_width),
                 ]
         logging.debug("cmd={}".format(cmd))
         with open(hdf5_out_filename + '.log', 'a') as logfile:

--- a/vcfnp/array.py
+++ b/vcfnp/array.py
@@ -247,7 +247,7 @@ def _mk_cache_fn(vcf_fn, array_type, region=None, cachedir=None):
         cache_fn = os.path.join(cachedir, '%s.npy' % array_type)
     else:
         # loading a specific region
-        region = region.replace(':', '_').replace('-', '_')
+        region = region.replace(':', '__').replace('-', '_')
         cache_fn = os.path.join(cachedir, '%s.%s.npy' % (array_type, region))
     return cache_fn
 

--- a/vcfnp/eff.py
+++ b/vcfnp/eff.py
@@ -20,7 +20,7 @@ EFF_DEFAULT_DTYPE = [
     ('Effect_Impact', 'a8'),
     ('Functional_Class', 'a8'),
     ('Codon_Change', 'a7'),  # N.B., will lose information for indels
-    ('Amino_Acid_Change', 'a6'),  # N.B., will lose information for indels
+    ('Amino_Acid_Change', 'a8'),  # N.B., will lose information for indels
     ('Amino_Acid_Length', 'i4'),
     ('Gene_Name', 'a14'),  # N.B., may be too short for some species
     ('Transcript_BioType', 'a20'),


### PR DESCRIPTION
Trivial bugfix.  Default values for some parameters are defined as numbers, but Popen needs them to be strings.
